### PR TITLE
[275] fix bug, Get/user/findByEmail 200, now 404

### DIFF
--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -269,7 +269,7 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
     public final ResponseEntity<Object> handleWrongEmailException(WrongEmailException ex) {
         ValidationExceptionDto validationExceptionDto =
             new ValidationExceptionDto(AppConstant.REGISTRATION_EMAIL_FIELD_NAME, ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(validationExceptionDto);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(validationExceptionDto);
     }
 
     /*


### PR DESCRIPTION
When entering a non-existent e-mail for search, it gave 400 (although it says in the task that it gives 200), now it is corrected to 404
Changed HttpStatus from BAD_REQUEST to NOT_FOUND in CustomExceptionHandler