### PR TITLE
[251] fix bug, In Get all Users always response - 401

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -190,7 +190,7 @@ public class SecurityConfig {
                                 "/user/shopping-list-items/user-shopping-list-items",
                                 "/user/shopping-list-items")
                         .hasAnyRole(USER, ADMIN, UBS_EMPLOYEE, MODERATOR, EMPLOYEE)
-                        .requestMatchers(HttpMethod.GET,
+                        .requestMatchers(HttpMethod.GET, USER_LINK,
                                 "/user/all",
                                 "/user/roles",
                                 "/user/findUserForManagement",


### PR DESCRIPTION
Steps to reproduce:
Click on User controller
Click on GET /user/findAll  (http://localhost:8060/swagger-ui/index.html#/user-controller/findAll)
Get users by page
Click on 'Try out'
Click on Execute

Actual result                |      Expected result
401 Unauthorized       |       Response 200 OK

Fix it:
Adding USER_LINK to requestMatchers(HttpMethod.GET ensures that all requests to /user and sub-paths are handled correctly. This solution ensures that only users with the right roles can access these resources.