### PR TITLE
Bugfix #352 - In GET /user - Get User dto by principal (email) from access token response 200 OK - need 403 Forbidden FIXED

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -132,7 +132,7 @@ public class SecurityConfig {
                                 "/ownSecurity/signIn",
                                 "/ownSecurity/updatePassword")
                         .permitAll()
-                        .requestMatchers(HttpMethod.GET, USER_LINK,
+                        .requestMatchers(HttpMethod.GET,
                                 "/user/shopping-list-items/habits/{habitId}/shopping-list",
                                 "/user/{userId}/{habitId}/custom-shopping-list-items/available",
                                 "/user/{userId}/profile/", "/user/isOnline/{userId}/",

--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -209,7 +209,7 @@ public class UserController {
         @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
     })
     @GetMapping
-    public ResponseEntity<UserUpdateDto> getUserByPrincipal(@ApiIgnore @AuthenticationPrincipal Principal principal) {
+    public ResponseEntity<UserUpdateDto> getUserByPrincipal(@ApiIgnore Principal principal) {
         String email = principal.getName();
         return ResponseEntity.status(HttpStatus.OK).body(userService.getUserUpdateDtoByEmail(email));
     }


### PR DESCRIPTION
Removed from SecurityConfig "/user" endpoint to restrict role USER access to it;
Removed from UserController @AuthenticationPrincipal for getUserByPrincipal(...) cause it doesn't work in this case;