### PR TITLE
[291] fix bug, POST /user/search] In /user/search response 500 Internal Server Error

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -202,6 +202,7 @@ public class SecurityConfig {
                         .hasAnyRole(UBS_EMPLOYEE)
                         .requestMatchers(HttpMethod.POST,
                                 "/user/filter",
+                                "/user/search",
                                 "/ownSecurity/register")
                         .hasAnyRole(ADMIN)
                         .requestMatchers(HttpMethod.PATCH,


### PR DESCRIPTION
Steps to reproduce:
Sign-in as Admin
Click on User controller
Click on POST /user/search
Click on 'Try out'

Actual result     |     Expected result
Response 401   |     Response 200 OK

Fix it:
add "/user/search" in .requestMatchers(HttpMethod.POST, ...  .hasAnyRole(ADMIN)